### PR TITLE
Update OCP version, Readme and 'box_name' default name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Via dnf:
 ## Requirements
 [ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html): install using package manager
 
+[GitHub cli](https://cli.github.com/): install via `sudo dnf install gh`
+
 ## Installation
 Clone the repository and install Ansible community plugins:
 ```bash

--- a/fedora-distro-box.yml
+++ b/fedora-distro-box.yml
@@ -6,7 +6,7 @@
   pre_tasks:
     - name: Set box name as fact
       ansible.builtin.set_fact:
-        box_name: fedora-38
+        box_name: distrobox-fedora
 
     - name: Set base box homedir as fact
       ansible.builtin.set_fact:

--- a/tasks/openshift_packages_playbook.yml
+++ b/tasks/openshift_packages_playbook.yml
@@ -8,7 +8,7 @@
     url: https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/latest/openshift-client-linux-4.13.11.tar.gz
     dest: /tmp
 
-- name: Extract oc and ubectl
+- name: Extract oc and kubectl
   ansible.builtin.unarchive:
     src: /tmp/openshift-client-linux-4.13.11.tar.gz
     dest: '{{ box_homedir }}/.local/bin/'

--- a/tasks/openshift_packages_playbook.yml
+++ b/tasks/openshift_packages_playbook.yml
@@ -5,12 +5,12 @@
 
 - name: Download oc and kubectl
   ansible.builtin.get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/latest/openshift-client-linux-4.13.0.tar.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/latest/openshift-client-linux-4.13.11.tar.gz
     dest: /tmp
 
 - name: Extract oc and ubectl
   ansible.builtin.unarchive:
-    src: /tmp/openshift-client-linux-4.13.0.tar.gz
+    src: /tmp/openshift-client-linux-4.13.11.tar.gz
     dest: '{{ box_homedir }}/.local/bin/'
 
 # - name: Download kubectl


### PR DESCRIPTION
1. Expected default value of `box_name` is "_distrobox-fedora_" and not "_fedora-38_", code is failing
2. Update README with gh cli requirement (for the usage of rosa installation for example)
3. Update oc download path with valid one (url path no longer exists)